### PR TITLE
Add timeout to Connect() method

### DIFF
--- a/TitaniumAS.Opc.Client.sln
+++ b/TitaniumAS.Opc.Client.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.26403.7
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TitaniumAS.Opc.Client", "TitaniumAS.Opc.Client\TitaniumAS.Opc.Client.csproj", "{0F7347F4-79F1-4C63-8C75-60F8D1A7E950}"
 EndProject

--- a/TitaniumAS.Opc.Client/Da/IOpcDaServer.cs
+++ b/TitaniumAS.Opc.Client/Da/IOpcDaServer.cs
@@ -103,9 +103,16 @@ namespace TitaniumAS.Opc.Client.Da
         object ComObject { get; }
 
         /// <summary>
-        /// Connects the server instance to COM server.
+        /// Connects the server instance to COM server with timeout.
         /// </summary>
-        void Connect();
+        /// <param name="timeout">Timeout in timespan</param>
+        bool Connect(TimeSpan timeout);
+
+        /// <summary>
+        /// Connects the server instance to COM server with timeout.
+        /// </summary>
+        /// <param name="milliseconds">Timeout in milliseconds</param>
+        bool Connect(int milliseconds);
 
         /// <summary>
         /// Releases connection to COM server for the server instance.

--- a/TitaniumAS.Opc.Client/Da/IOpcDaServer.cs
+++ b/TitaniumAS.Opc.Client/Da/IOpcDaServer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
+using System.Threading.Tasks;
 using TitaniumAS.Opc.Client.Common;
 
 namespace TitaniumAS.Opc.Client.Da
@@ -103,16 +104,10 @@ namespace TitaniumAS.Opc.Client.Da
         object ComObject { get; }
 
         /// <summary>
-        /// Connects the server instance to COM server with timeout.
+        /// Asynchronously connects to the OpcDa server
         /// </summary>
-        /// <param name="timeout">Timeout in timespan</param>
-        bool Connect(TimeSpan timeout);
-
-        /// <summary>
-        /// Connects the server instance to COM server with timeout.
-        /// </summary>
-        /// <param name="milliseconds">Timeout in milliseconds</param>
-        bool Connect(int milliseconds);
+        /// <returns>A task to wait upon</returns>
+        Task ConnectAsync();
 
         /// <summary>
         /// Releases connection to COM server for the server instance.

--- a/TitaniumAS.Opc.Client/Da/OpcDaServer.cs
+++ b/TitaniumAS.Opc.Client/Da/OpcDaServer.cs
@@ -110,7 +110,7 @@ namespace TitaniumAS.Opc.Client.Da
         }
 
         /// <summary>
-        ///     Connects the server instance to COM server.
+        /// Connects the server instance to COM server.
         /// </summary>
         /// <exception cref="System.InvalidOperationException">Already connected to the OPC DA server.</exception>
         public void Connect()
@@ -141,6 +141,13 @@ namespace TitaniumAS.Opc.Client.Da
             OnConnectionStateChanged(true);
         }
 
+        /// <summary>
+        /// Asynchronout connect method
+        /// </summary>
+        /// <returns>
+        /// A running task to wait on for connect
+        /// </returns>
+        /// <seealso cref="Connect()"/>
         public Task ConnectAsync()
         {
             return Task.Factory.StartNew(() => { Connect(); });


### PR DESCRIPTION
Added a timeout (Timespan and millisecond) to the OPC DA server connect methods to prevent hangs when this application connects to OPC servers.